### PR TITLE
modified indent rule for switch statements. Fixes #2.

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -48,7 +48,7 @@ module.exports = {
       properties: 'never'
     }],
     // this option sets a specific tab width for your code
-    indent: [ERROR, 2],
+    indent: [ERROR, 2, {"SwitchCase": 1}],
     // specify whether double or single quotes should be used in JSX attributes
     'jsx-quotes': ERROR,
     // enforces spacing between keys and values in object literal properties


### PR DESCRIPTION
requires the `case` statement to be indented inside the `switch` statement

```js
switch (condition) {
  case 'FIRST': 
    doSomething();
    break;

  case 'SECOND':
    doSomethingElse();
    break;

  default: 
    break;
}
```
