### PR TITLE
update react rules, rule definition changed.

### DIFF
--- a/react.js
+++ b/react.js
@@ -37,7 +37,7 @@ module.exports = {
     // Prevent usage of dangerous JSX properties
     'react/no-danger': 0,
     // Prevent usage of setState in componentDidMount
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
+    'react/no-did-mount-set-state': 2,
     // Prevent usage of setState in componentDidUpdate
     'react/no-did-update-set-state': 2,
     // Prevent multiple component definition per file
@@ -51,7 +51,9 @@ module.exports = {
     // Restrict file extensions that may be required
     'react/require-extension': 0,
     // Prevent extra closing tags for components without children
-    'react/self-closing-comp': 2,
+    'react/self-closing-comp': [2, {
+      component: true
+    }],
     // Enforce component methods order
     'react/sort-comp': [2, {
       order: [


### PR DESCRIPTION
Rule `no-did-mount-set-state` no longer takes `allow-in-func`, that's the default behavior. To disable, use `disallow-in-func`.

Rule `self-closing-comp` applies to `html` as well, but we do want to be able to use non-self-closing empty divs, e.g. `<div></div>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/eslint-config/32)
<!-- Reviewable:end -->
