### PR TITLE
make eslint a real dependency / bump versions / rename deprecated rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ comment of `@differ #{dang good reason}`.
 To use the mongodb-js shareable config, first run:
 
 ```bash
-npm install --save-dev eslint eslint-config-mongodb-js
+npm install --save-dev eslint-config-mongodb-js
 ```
 
 The barebones mongodb-js `./.eslintrc` file looks like:

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "ci": "mocha",
     "test": "mocha"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "babel-eslint": "^6.0.0",
-    "eslint": "^2.5.3",
-    "eslint-plugin-react": "^5.2.2",
-    "mocha": "^2.3.4",
+    "eslint": "^3.3.1",
+    "eslint-plugin-react": "^6.1.2"
+  },
+  "devDependencies": {
+    "mocha": "^3.0.2",
     "mongodb-js-fmt": "0.0.3",
     "mongodb-js-precommit": "^0.2.8",
     "pre-commit": "^1.1.2"

--- a/react.js
+++ b/react.js
@@ -66,6 +66,6 @@ module.exports = {
       ]
     }],
     // Prevent missing parentheses around multilines JSX
-    'react/wrap-multilines': 2
+    'react/jsx-wrap-multilines': 2
   }
 };


### PR DESCRIPTION
Before this PR, `eslint` (and `babel-eslint`, `eslint-plugin-react`) were `devDependencies`, which means they would not be installed into a different module via `npm install`. It required these modules to be installed separately, and all kinds of issues arose when the versions did not match with those assumed here.

Adding `eslint-config-mongodb-js` (this module) as a devDependency to a module should take care of all the eslint (and plugins) dependencies. It does now, by moving the required dependencies to the `dependencies` section.

Additional changes: 

- bumped versions to something current
- renamed deprecated `react/wrap-multilines` to `react/jsx-wrap-multilines` rule

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/eslint-config/38)
<!-- Reviewable:end -->
