### PR TITLE
disable rule: consistent-return

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -21,7 +21,7 @@ module.exports = {
     // specify the maximum cyclomatic complexity allowed in a program
     complexity: [ERROR, 11],
     // require return statements to either always or never specify values
-    'consistent-return': ERROR,
+    'consistent-return': IGNORE,
     // specify curly brace conventions for all control statements
     curly: [ERROR, 'multi-line'],
     // require default case in switch statements


### PR DESCRIPTION
Reason: we often use return to avoid an else branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/eslint-config/39)
<!-- Reviewable:end -->
