### PR TITLE
fix: Remove ecmaFeatures rules that are now deprecated 

### DIFF
--- a/react.js
+++ b/react.js
@@ -10,9 +10,6 @@ module.exports = {
   plugins: [
     'react'
   ],
-  ecmaFeatures: {
-    jsx: true
-  },
   rules: {
     // Prevent missing displayName in a React component definition
     'react/display-name': 0,

--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -13,24 +13,6 @@ module.exports = {
   env: {
     es6: false
   },
-  ecmaFeatures: {
-    arrowFunctions: true,
-    blockBindings: true,
-    classes: true,
-    defaultParams: true,
-    destructuring: true,
-    forOf: true,
-    generators: false,
-    modules: true,
-    objectLiteralComputedProperties: true,
-    objectLiteralDuplicateProperties: false,
-    objectLiteralShorthandMethods: true,
-    objectLiteralShorthandProperties: true,
-    spread: true,
-    superInFunctions: true,
-    templateStrings: true,
-    jsx: true
-  },
   rules: {
     // require parens in arrow function arguments
     'arrow-parens': IGNORE,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,6 @@ describe('eslint-config-mongodb-js', function() {
     var config = require('../react');
     assert(Array.isArray(config.extends));
     assert(isObject(config.rules));
-    assert(isObject(config.ecmaFeatures));
     assert.equal(config.plugins[0], 'react');
   });
   


### PR DESCRIPTION
## Description

Remove `ecmaFeatures` block from rules as it is now deprecated and has no effect following upgrade to eslint@4.x.x.